### PR TITLE
Change to test_flora

### DIFF
--- a/test/logic/test_flora.flr
+++ b/test/logic/test_flora.flr
@@ -3,4 +3,6 @@ john[ likes->curry ].
 sandy[ likes->mushrooms ].
 
 ?x[ dislikes->?y ] :-
-	?x[ not( likes->?y ) ].
+	?_someone[ likes->?y ],
+	?x[ likes->?_something ],
+	\naf ?x[ likes->?y ].


### PR DESCRIPTION
In my install today, based on the latest Flora-2 version, the rule was not firing properly.

you could probably get away with just \neg, but I imagine the list of entities matching ?x that do not like foods would include curry, which does not like mushrooms or itself, for example.

If you wanted show how frame syntax classes can be used to achieve the same thing, you could say:
john:Person[likes->curry:Food].
sandy:Person[likes->mushrooms:Food].
?x[dislikes->?y] :-
   ?x:Person, ?y:Food,
   \naf ?x[likes->?y].